### PR TITLE
Librivox Archive Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,15 @@
             <td><a href="https://github.com/ipfs/archives/issues/52">#52</a></td>
             <td></td>
         </tr>
+        <tr>
+            <td>Librivox Audio Books</td>
+            <td>2.0 TiB</td>
+            <td><a href="https://ipfs.io/ipfs/QmXyNMhV8bQFp6wzoVpkz3NqDi7Fj72Deg7KphAuew3RYU"><code>/ipfs/QmXyNMhV8bQFp6wzoVpkz3NqDi7Fj72Deg7KphAuew3RYU</code></a></td>
+            <td><a href="https://github.com/ipfs/archives/issues/189">#189</a></td>
+            <td>
+                <a href="https://ipfs.io/ipfs/QmXyNMhV8bQFp6wzoVpkz3NqDi7Fj72Deg7KphAuew3RYU/catalog/">Catalog</a>
+            </td>
+        </tr>
         </tbody>
     </table>
 </div>


### PR DESCRIPTION
This adds a link to the current version of the Librivox archive, including a front-end UI, JSON file of book details, and the script used to gather the archive. This is for issue https://github.com/ipfs/archives/issues/189.